### PR TITLE
Fix Getting and setting current user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea
 /vendor/
 composer.lock

--- a/src/Factories/Order.php
+++ b/src/Factories/Order.php
@@ -79,11 +79,11 @@ class Order extends WP_UnitTest_Factory_For_Thing {
 	}
 
 	private function api_call_setup() {
-		$this->old_user = wp_get_current_user();
+		$this->old_user = get_current_user_id();
 
 		// Setup the administrator user so we can actually retrieve the order.
 		$user = new \WP_User( 1 );
-		wp_set_current_user( $user );
+		wp_set_current_user( $user->ID );
 
 		WC()->api->includes();
 		WC()->api->register_resources( new WC_API_Server( '/' ) );

--- a/src/Factories/Product.php
+++ b/src/Factories/Product.php
@@ -79,11 +79,11 @@ class Product extends WP_UnitTest_Factory_For_Thing {
 	}
 
 	private function api_call_setup() {
-		$this->old_user = wp_get_current_user();
+		$this->old_user = get_current_user_id();
 
 		// Setup the administrator user so we can actually retrieve the order.
 		$user = new \WP_User( 1 );
-		wp_set_current_user( $user );
+		wp_set_current_user( $user->ID );
 	}
 
 

--- a/src/Factories/TaxRate.php
+++ b/src/Factories/TaxRate.php
@@ -88,11 +88,11 @@ class TaxRate extends WP_UnitTest_Factory_For_Thing {
 	}
 
 	private function api_call_setup() {
-		$this->old_user = wp_get_current_user();
+		$this->old_user = get_current_user_id();
 
 		// Setup the administrator user so we can actually retrieve the order.
 		$user = new \WP_User( 1 );
-		wp_set_current_user( $user );
+		wp_set_current_user( $user->ID );
 	}
 
 


### PR DESCRIPTION
Thanks for the handy addition to wp-browser.

While using it, I noticed that the user is incorrectly backed up and restored - used functions expect the user ID, not the entire WP_User object.