### PR TITLE
add coupon factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ Example:
 ```php
 $this->factory()->coupon->create_and_get(
     array(
-        'code'            => '25off',
-        'discount_type'   => 'percent',
-        'amount'          => '10',
-        'individual_use' => true,
-        'exclude_sale_items'    => true,
-        'minimum_amount'    => '100.00',
+        'code'               => '25off',
+        'discount_type'      => 'percent',
+        'amount'             => '10',
+        'individual_use'     => true,
+        'exclude_sale_items' => true,
+        'minimum_amount'     => '100.00',
     )
 );
 ```

--- a/README.md
+++ b/README.md
@@ -181,6 +181,31 @@ $this->factory()->tax_rate->create_and_get(
 );
 ```
 
+### Coupons
+
+You can access the coupon factory by using `$this->factory()->coupon` within a WooCommerce integration test. 
+
+The main method you'll use is `create_and_get( $args )`. The input you can give to a coupon are the same as you can give to the coupon creation API endpoint. 
+
+`create_and_get($args)` returns the result of `new WC_Coupon( $coupon_id )` for the created object.
+
+See https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-coupon
+
+Example:
+
+```php
+$this->factory()->coupon->create_and_get(
+    array(
+        'code'            => '25off',
+        'discount_type'   => 'percent',
+        'amount'          => '10',
+        'individual_use' => true,
+        'exclude_sale_items'    => true,
+        'minimum_amount'    => '100.00',
+    )
+);
+```
+
 ## Testcases
 For most testcases you will want to use `\LevelLevel\WPBrowserWooCommerce\WCTestCase`
 

--- a/src/Factories/Coupon.php
+++ b/src/Factories/Coupon.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace LevelLevel\WPBrowserWooCommerce\Factories;
+
+use Exception;
+use TypeError;
+use WC_Coupon;
+use WP_UnitTest_Factory_For_Thing;
+
+class Coupon extends WP_UnitTest_Factory_For_Thing {
+	/**
+	 * Creates a coupon. Using the API method.
+	 *
+	 * @param array $args See https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-coupon
+	 *
+	 * @return int
+	 */
+	public function create_object( $args ) {
+		$this->api_call_setup();
+
+		$request = new \WP_REST_Request( 'post', '/wc/v3/coupons' );
+		$request->add_header( 'Content-Type', 'application/json' );
+
+		$request->set_body( json_encode( $args ) ); //phpcs:ignore
+		$response = rest_do_request( $request );
+
+		$this->api_call_teardown();
+
+		if ( $response->is_error() ) {
+			throw new Exception( $response->get_data()['message'] );
+		}
+		return $response->get_data()['id'];
+	}
+
+	/**
+	 * Updates a coupon.
+	 *
+	 * @param int $object Coupon ID.
+	 * @param array $args See https://woocommerce.github.io/woocommerce-rest-api-docs/#update-a-coupon
+	 *
+	 * @return int
+	 */
+	public function update_object( $object, $fields ) {
+		if ( ! is_int( $object ) ) {
+			throw new TypeError( '$object must be an int' );
+		}
+		$this->api_call_setup();
+
+		$request = new \WP_REST_Request( 'put', '/wc/v3/coupons/' . $object );
+		$request->add_header( 'Content-Type', 'application/json' );
+
+		$request->set_body( json_encode( $fields ) ); //phpcs:ignore
+		$response = rest_do_request( $request );
+
+		$this->api_call_teardown();
+
+		if ( $response->is_error() ) {
+			throw new Exception( $response->get_data()['message'] );
+		}
+
+		return $response->get_data()['id'];
+	}
+
+	/**
+	 * Gets a woocommerce coupon.
+	 *
+	 * @param int $object_id The coupon ID.
+	 *
+	 * @return WC_Coupon
+	 */
+	public function get_object_by_id( $object_id ) {
+		$coupon = new WC_Coupon( $object_id );
+		if ( ! $coupon instanceof WC_Coupon ) {
+			throw new Exception( 'Could not retrieve coupon with ID ' . $object_id );
+		}
+		return $coupon;
+	}
+
+	private function api_call_setup() {
+		$this->old_user = wp_get_current_user();
+
+		// Setup the administrator user so we can actually retrieve the order.
+		$user = new \WP_User( 1 );
+		wp_set_current_user( $user );
+	}
+
+
+	private function api_call_teardown() {
+		wp_set_current_user( $this->old_user );
+	}
+}

--- a/src/Factories/Coupon.php
+++ b/src/Factories/Coupon.php
@@ -77,11 +77,11 @@ class Coupon extends WP_UnitTest_Factory_For_Thing {
 	}
 
 	private function api_call_setup() {
-		$this->old_user = wp_get_current_user();
+		$this->old_user = get_current_user_id();
 
 		// Setup the administrator user so we can actually retrieve the order.
 		$user = new \WP_User( 1 );
-		wp_set_current_user( $user );
+		wp_set_current_user( $user->ID );
 	}
 
 

--- a/src/WC_UnitTest_Factory.php
+++ b/src/WC_UnitTest_Factory.php
@@ -2,6 +2,7 @@
 
 namespace LevelLevel\WPBrowserWooCommerce;
 
+use LevelLevel\WPBrowserWooCommerce\Factories\Coupon;
 use LevelLevel\WPBrowserWooCommerce\Factories\Product;
 use LevelLevel\WPBrowserWooCommerce\Factories\Order;
 use LevelLevel\WPBrowserWooCommerce\Factories\TaxRate;
@@ -25,8 +26,9 @@ class WC_UnitTest_Factory extends WP_UnitTest_Factory {
 
 	public function __construct() {
 		parent::__construct();
-		$this->product = new Product( $this );
-		$this->order   = new Order( $this );
-		$this->tax_rate   = new TaxRate( $this );
+		$this->product  = new Product( $this );
+		$this->order    = new Order( $this );
+		$this->tax_rate = new TaxRate( $this );
+		$this->coupon   = new Coupon( $this );
 	}
 }


### PR DESCRIPTION
## Description

Adds coupon factory for creating WooCommerce Coupons.

## How Has This Been Tested?

I've created a coupon in one of our projects using the following code, which worked flawlessly.

```php

		$this->coupon = $this->factory()->coupon->create_and_get(
			array(
				'code'               => '25off',
				'discount_type'      => 'percent',
				'amount'             => '25',
				'individual_use'     => true,
				'exclude_sale_items' => true,
			)
		);

```