### PR TITLE
add subscriptions factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ public function test_can_add_sample_to_cart() {
 
 ### Roadmap
 
-The main focus is on implementing more factories for other WooCommerce objects such as **coupons**, **customers**, **refunds** and **shipping methods**.
+The main focus is on implementing more factories for other WooCommerce objects such as **customers**, **refunds** and **shipping methods**.
 
 After this, focus might shift to popular extensions for WooCommerce, such as Subscriptions or Bookings.
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,64 @@ $this->factory()->coupon->create_and_get(
 );
 ```
 
+### Subscriptions
+
+The subscription factory can only be used when the [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) plugin is installed and activated.
+
+You can access the subscription factory by using `$this->factory()->subscription` within a WooCommerce integration test. 
+
+The main method you'll use is `create_and_get( $args )`. The input you can give to a subscription are the same as you can give to the subscription creation API endpoint. 
+
+`create_and_get($args)` returns the result of `wcs_get_subscription( $subscription_id )` for the created object.
+
+See https://woocommerce.github.io/subscriptions-rest-api-docs/v1.html#create-a-subscription
+
+Example:
+
+```php
+$this->factory()->subscription->create_and_get(
+    array(
+        'customer_id' => 1,
+        'parent_id' => 1,
+        'status' => 'pending',
+        'billing_period' => 'month',
+        'billing_interval' => 1,
+        'start_date' => ( new DateTime( 'now', wp_timezone() ) )->format( 'Y-m-d H:i:s' ),
+        'next_payment_date' => ( new DateTime( '+1 month', wp_timezone() ) )->format( 'Y-m-d H:i:s' ),
+        'payment_method' => '',
+        'billing' => array(
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_1' => 'Market',
+            'house_number' => '1',
+            'address_2' => '',
+            'city' => 'Rotterdam',
+            'postcode' => '3456AB',
+            'country' => 'NL',
+            'email' => 'john.doe@example.com',
+        ),
+        'shipping' => array(
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_1' => 'Memory Lane',
+            'house_number' => '1',
+            'address_2' => '',
+            'city' => 'Rotterdam',
+            'postcode' => '3456AB',
+            'country' => 'NL',
+        ),
+        'line_items' => array(
+            array(
+                'product_id' => 1,
+                'quantity' => 1,
+                'subtotal' => '10.00',
+                'total' => '10.00',
+            )
+        )
+    )
+);
+```
+
 ## Testcases
 For most testcases you will want to use `\LevelLevel\WPBrowserWooCommerce\WCTestCase`
 

--- a/src/Factories/Subscription.php
+++ b/src/Factories/Subscription.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace LevelLevel\WPBrowserWooCommerce\Factories;
+
+use Exception;
+use TypeError;
+use WC_Subscription;
+use WP_UnitTest_Factory_For_Thing;
+
+class Subscription extends WP_UnitTest_Factory_For_Thing {
+	/**
+	 * Creates a subscription. Using the API method.
+	 *
+	 * @param array $args See https://woocommerce.github.io/subscriptions-rest-api-docs/v1.html#create-a-subscription
+	 *
+	 * @return int
+	 */
+	public function create_object( $args ) {
+		$this->api_call_setup();
+
+		$request = new \WP_REST_Request( 'post', '/wc/v1/subscriptions' );
+		$request->add_header( 'Content-Type', 'application/json' );
+
+		$request->set_body( json_encode( $args ) ); //phpcs:ignore
+		$response = rest_do_request( $request );
+
+		$this->api_call_teardown();
+
+		if ( $response->is_error() ) {
+			throw new Exception( $response->get_data()['message'] );
+		}
+		return $response->get_data()['id'];
+	}
+
+	/**
+	 * Updates a subscription.
+	 *
+	 * @param int $object Subscription ID.
+	 * @param array $args See https://woocommerce.github.io/subscriptions-rest-api-docs/v1.html#update-a-subscription
+	 *
+	 * @return int
+	 */
+	public function update_object( $object, $fields ) {
+		if ( ! is_int( $object ) ) {
+			throw new TypeError( '$object must be an int' );
+		}
+		$this->api_call_setup();
+
+		$request = new \WP_REST_Request( 'put', '/wc/v1/subscriptions/' . $object );
+		$request->add_header( 'Content-Type', 'application/json' );
+
+		$request->set_body( json_encode( $fields ) ); //phpcs:ignore
+		$response = rest_do_request( $request );
+
+		$this->api_call_teardown();
+
+		if ( $response->is_error() ) {
+			throw new Exception( $response->get_data()['message'] );
+		}
+
+		return $response->get_data()['id'];
+	}
+
+	/**
+	 * Gets a woocommerce subscription.
+	 *
+	 * @param int $object_id The subscription ID.
+	 *
+	 * @return WC_Subscription
+	 */
+	public function get_object_by_id( $object_id ) {
+		$subscription = wcs_get_subscription( $object_id );
+		if ( ! $subscription instanceof WC_Subscription ) {
+			throw new Exception( 'Could not retrieve subscription with ID ' . $object_id );
+		}
+		return $subscription;
+	}
+
+	private function api_call_setup() {
+		$this->old_user = get_current_user_id();
+
+		// Setup the administrator user so we can actually retrieve the order.
+		$user = new \WP_User( 1 );
+		wp_set_current_user( $user->ID );
+	}
+
+
+	private function api_call_teardown() {
+		wp_set_current_user( $this->old_user );
+	}
+}

--- a/src/WC_UnitTest_Factory.php
+++ b/src/WC_UnitTest_Factory.php
@@ -5,6 +5,7 @@ namespace LevelLevel\WPBrowserWooCommerce;
 use LevelLevel\WPBrowserWooCommerce\Factories\Coupon;
 use LevelLevel\WPBrowserWooCommerce\Factories\Product;
 use LevelLevel\WPBrowserWooCommerce\Factories\Order;
+use LevelLevel\WPBrowserWooCommerce\Factories\Subscription;
 use LevelLevel\WPBrowserWooCommerce\Factories\TaxRate;
 use WP_UnitTest_Factory;
 
@@ -24,11 +25,22 @@ class WC_UnitTest_Factory extends WP_UnitTest_Factory {
 	 */
 	public $tax_rate;
 
+	/**
+	 * @var Coupon
+	 */
+	public $coupon;
+
+	/**
+	 * @var Subscription
+	 */
+	public $subscription;
+
 	public function __construct() {
 		parent::__construct();
-		$this->product  = new Product( $this );
-		$this->order    = new Order( $this );
-		$this->tax_rate = new TaxRate( $this );
-		$this->coupon   = new Coupon( $this );
+		$this->product      = new Product( $this );
+		$this->order        = new Order( $this );
+		$this->tax_rate     = new TaxRate( $this );
+		$this->coupon       = new Coupon( $this );
+		$this->subscription = new Subscription( $this );
 	}
 }


### PR DESCRIPTION
## Description
Adds subscription factory for woocommerce subscriptions.
Uses the subscriptions rest api https://woocommerce.github.io/subscriptions-rest-api-docs/v1.html

## Tested

Has been tested using following code.

```php
		$address = array(
			'first_name' => 'Firstname',
			'last_name'  => 'Lastname',
			'company'    => 'Company',
			'address_1'  => 'Streetname 1',
			'address_2'  => '',
			'city'       => 'City',
			'state'      => '',
			'postcode'   => '1234AB',
			'country'    => 'NL',
			'email'      => 'test@example.com',
		);
		$this->subscription = $this->factory()->subscription->create_and_get(
			array(
				'customer_id' => 1,
				'parent_id' => $this->order->get_id(),
				'status' => 'pending',
				'billing_period' => 'month',
				'billing_interval' => 1,
				'start_date' => ( new DateTime( 'now', wp_timezone() ) )->format( 'Y-m-d H:i:s' ),
				'next_payment_date' => ( new DateTime( '+1 month', wp_timezone() ) )->format( 'Y-m-d H:i:s' ),
				'payment_method' => '',
				'billing' => $address,
				'shipping' => $address,
				'line_items' => array(
					array(
						'product_id' => $this->product->get_id(),
						'quantity' => 1,
						'subtotal' => '10.00',
						'total' => '10.00',
					)
				)
			)
		);
```