### PR TITLE
Restore instances after test runs

### DIFF
--- a/src/WCTestCase.php
+++ b/src/WCTestCase.php
@@ -5,6 +5,11 @@ namespace LevelLevel\WPBrowserWooCommerce;
 use Codeception\TestCase\WPTestCase;
 
 class WCTestCase extends WPTestCase {
+	private $original_cart;
+	private $original_session;
+	private $original_customer;
+	private $original_query;
+
 	/**
 	 * @return WC_UnitTest_Factory
 	 */
@@ -14,5 +19,23 @@ class WCTestCase extends WPTestCase {
 			$factory = new WC_UnitTest_Factory();
 		}
 		return $factory;
+	}
+
+	public function _setUp()
+	{
+		parent::_setUp();
+		$this->original_cart = WC()->cart;
+		$this->original_session = WC()->session;
+		$this->original_customer = WC()->customer;
+		$this->original_query = WC()->query;
+	}
+
+	public function _tearDown()
+	{
+		parent::_tearDown();
+		WC()->cart = $this->original_cart;
+		WC()->session = $this->original_session;
+		WC()->customer = $this->original_customer;
+		WC()->query = $this->original_query;
 	}
 }


### PR DESCRIPTION
Restore WC() property instances after test runs. They might influence subsequent runs if not reset.