### PR TITLE
Support WP Browser 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "lucatume/wp-browser": "^2|^3|^4"
+        "lucatume/wp-browser": "^4"
     },
     "autoload": {
         "psr-4":{
-            "LevelLevel\\WPBrowserWooCommerce\\": "src"       
+            "LevelLevel\\WPBrowserWooCommerce\\": "src"
         }
     }
 }

--- a/src/Factories/ShippingZoneMethod.php
+++ b/src/Factories/ShippingZoneMethod.php
@@ -7,16 +7,12 @@ use Exception;
 use TypeError;
 use WC_Shipping_Method;
 use WC_Shipping_Zone;
-use WC_Shipping_Zones;
 use WP_UnitTest_Factory_For_Thing;
 
 class ShippingZoneMethod extends WP_UnitTest_Factory_For_Thing {
 	use APICalling;
 
-	/**
-	 * @var int
-	 */
-	private $zone_id = null;
+	private ?int $zone_id = null;
 
 	public function zone_id( int $zone_id ): self {
 		$this->zone_id = $zone_id;

--- a/src/WCAjaxTestCase.php
+++ b/src/WCAjaxTestCase.php
@@ -2,15 +2,12 @@
 
 namespace LevelLevel\WPBrowserWooCommerce;
 
-use Codeception\TestCase\WPAjaxTestCase;
+use lucatume\WPBrowser\TestCase\WPAjaxTestCase;
 
 class WCAjaxTestCase extends WPAjaxTestCase {
 	private $original_acf_stores;
 
-	/**
-	 * @return WC_UnitTest_Factory
-	 */
-	protected static function factory() {
+	protected static function factory(): WC_UnitTest_Factory {
 		static $factory = null;
 		if ( ! $factory ) {
 			$factory = new WC_UnitTest_Factory();

--- a/src/WCTestCase.php
+++ b/src/WCTestCase.php
@@ -2,7 +2,7 @@
 
 namespace LevelLevel\WPBrowserWooCommerce;
 
-use Codeception\TestCase\WPTestCase;
+use lucatume\WPBrowser\TestCase\WPTestCase;
 
 class WCTestCase extends WPTestCase {
 	private $original_acf_stores;

--- a/src/WC_UnitTest_Factory.php
+++ b/src/WC_UnitTest_Factory.php
@@ -12,30 +12,14 @@ use LevelLevel\WPBrowserWooCommerce\Factories\TaxRate;
 use WP_UnitTest_Factory;
 
 class WC_UnitTest_Factory extends WP_UnitTest_Factory {
-	/**
-	 * @var Product
-	 */
-	public $product;
 
-	/**
-	 * @var Order
-	 */
-	public $order;
-
-	/**
-	 * @var TaxRate
-	 */
-	public $tax_rate;
-
-	/**
-	 * @var Coupon
-	 */
-	public $coupon;
-
-	/**
-	 * @var Subscription
-	 */
-	public $subscription;
+	public Product $product;
+	public Order $order;
+	public TaxRate $tax_rate;
+	public Coupon $coupon;
+	public ShippingZone $shipping_zone;
+	public ShippingZoneMethod $shipping_zone_method;
+	public Subscription $subscription;
 
 	public function __construct() {
 		parent::__construct();


### PR DESCRIPTION
Updates the package to only support wp-browser 4. This enabled usage of the `lucatume\WPBrowser\TestCase\WPTestCase` class, which provides better support for intellisense when writing tests.